### PR TITLE
chore(vacs-protocol): bump protocol version to 2.0.0

### DIFF
--- a/vacs-protocol/src/lib.rs
+++ b/vacs-protocol/src/lib.rs
@@ -7,7 +7,7 @@ pub mod vatsim;
 #[cfg(feature = "ws")]
 pub mod ws;
 
-pub const VACS_PROTOCOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const VACS_PROTOCOL_VERSION: &str = "2.0.0";
 
 #[cfg(feature = "profile")]
 pub(crate) mod sealed {


### PR DESCRIPTION
now that we're no longer handling all sub-crates via release-please (#551), we need to manually maintain the protocol version