### PR TITLE
fix: move third party licenses bundling to release config

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -173,8 +173,13 @@ jobs:
           git describe --tags --always
           # override version info built into client
           echo "VACS_VERSION_OVERRIDE=$VERSION" >> "$GITHUB_ENV"
-          # build tauri user config with version info
-          echo "EXTRA_TAURI_ARGS=--config '{\"version\":\"$VERSION\"}'" >> "$GITHUB_ENV"
+          # build tauri user config with version info and release config
+          echo "EXTRA_TAURI_ARGS=--config '{\"version\":\"$VERSION\"}' --config tauri.release.conf.json" >> "$GITHUB_ENV"
+
+      - name: Set release tauri config
+        if: github.event_name != 'workflow_dispatch'
+        shell: bash
+        run: echo "EXTRA_TAURI_ARGS=--config tauri.release.conf.json" >> "$GITHUB_ENV"
 
       - name: Install build dependencies (Linux)
         if: matrix.platform == 'ubuntu-22.04'

--- a/vacs-client/tauri.conf.json
+++ b/vacs-client/tauri.conf.json
@@ -38,8 +38,7 @@
       "../LICENSE-APACHE": "LICENSE-APACHE",
       "../LICENSE-MIT": "LICENSE-MIT",
       "../README.md": "README.md",
-      "frontend/src/assets/fonts/OFL-noto.txt": "licenses/OFL-noto.txt",
-      "../THIRD_PARTY_LICENSES.html": "licenses/THIRD_PARTY_LICENSES.html"
+      "frontend/src/assets/fonts/OFL-noto.txt": "licenses/OFL-noto.txt"
     },
     "windows": {
       "nsis": {

--- a/vacs-client/tauri.release.conf.json
+++ b/vacs-client/tauri.release.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": {
+      "../THIRD_PARTY_LICENSES.html": "licenses/THIRD_PARTY_LICENSES.html"
+    }
+  }
+}


### PR DESCRIPTION
allows for local/CI builds without generated license file