### PR TITLE
chore: bump vacs-server to 2.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8437,7 +8437,7 @@ dependencies = [
 
 [[package]]
 name = "vacs-server"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vacs-server/Cargo.toml
+++ b/vacs-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vacs-server"
-version = "2.3.2"
+version = "2.3.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
trigger release-please since dependency update did not touch monitored file