### PR TITLE
fix(vacs-server): stop the active calls metric getting stuck above zero

### DIFF
--- a/vacs-server/src/state/calls.rs
+++ b/vacs-server/src/state/calls.rs
@@ -148,16 +148,6 @@ impl ActiveCallEntry {
         }
     }
 
-    pub fn peer(&self, client_id: &ClientId) -> Option<&ClientId> {
-        if self.caller_id == *client_id {
-            Some(&self.callee_id)
-        } else if self.callee_id == *client_id {
-            Some(&self.caller_id)
-        } else {
-            None
-        }
-    }
-
     pub fn involves(&self, client_id: &ClientId) -> bool {
         self.caller_id == *client_id || self.callee_id == *client_id
     }

--- a/vacs-server/src/state/calls/manager.rs
+++ b/vacs-server/src/state/calls/manager.rs
@@ -29,7 +29,6 @@ pub struct CallManager {
     active_calls: RwLock<HashMap<CallId, ActiveCallEntry>>,
     client_incoming_calls: RwLock<HashMap<ClientId, HashSet<CallId>>>,
     client_outgoing_calls: RwLock<HashMap<ClientId, CallId>>,
-    client_active_calls: RwLock<HashMap<ClientId, CallId>>,
 }
 
 impl Default for CallManager {
@@ -54,7 +53,6 @@ impl CallManager {
             active_calls: RwLock::new(HashMap::new()),
             client_incoming_calls: RwLock::new(HashMap::new()),
             client_outgoing_calls: RwLock::new(HashMap::new()),
-            client_active_calls: RwLock::new(HashMap::new()),
         }
     }
 
@@ -75,6 +73,12 @@ impl CallManager {
 
     pub fn active_call(&self, call_id: &CallId) -> Option<ActiveCall> {
         self.active_calls.read().get(call_id).map(Into::into)
+    }
+
+    /// Number of currently active calls. This is the value the `vacs_calls_active` gauge tracks,
+    /// since every entry holds a [`CallGuard`](crate::metrics::guards::CallGuard).
+    pub fn active_call_count(&self) -> usize {
+        self.active_calls.read().len()
     }
 
     pub fn start_call_attempt(
@@ -193,11 +197,6 @@ impl CallManager {
         );
 
         self.active_calls.write().insert(*call_id, active);
-        {
-            let mut client_active_calls = self.client_active_calls.write();
-            client_active_calls.insert(ringing.caller_id.clone(), *call_id);
-            client_active_calls.insert(accepting_client_id.clone(), *call_id);
-        }
 
         Some(ringing.complete(CallAttemptOutcome::Accepted))
     }
@@ -258,12 +257,6 @@ impl CallManager {
             }
         }?;
 
-        {
-            let mut client_active_calls = self.client_active_calls.write();
-            client_active_calls.remove(&active.caller_id);
-            client_active_calls.remove(&active.callee_id);
-        }
-
         Some(ActiveCall::from(active))
     }
 
@@ -272,7 +265,6 @@ impl CallManager {
         tracing::trace!("Cleaning up client calls");
 
         let mut cleaned_ringing_calls: Vec<RingingCall> = Vec::new();
-        let mut cleaned_active_call: Option<ActiveCall> = None;
 
         let outgoing_call_id = { self.client_outgoing_calls.write().remove(client_id) };
         if let Some(outgoing_call_id) = outgoing_call_id {
@@ -326,25 +318,7 @@ impl CallManager {
             }
         }
 
-        let active_call_id = { self.client_active_calls.write().remove(client_id) };
-        if let Some(active_call_id) = active_call_id {
-            let active = { self.active_calls.write().remove(&active_call_id) };
-            if let Some(active) = active
-                && let Some(peer_id) = active.peer(client_id)
-            {
-                {
-                    let mut client_active_calls = self.client_active_calls.write();
-                    if client_active_calls
-                        .get(peer_id)
-                        .is_some_and(|c| *c == active_call_id)
-                    {
-                        client_active_calls.remove(peer_id);
-                    }
-                }
-
-                cleaned_active_call = Some(ActiveCall::from(active));
-            }
-        }
+        let cleaned_active_calls = self.remove_active_calls_of(client_id);
 
         for ringing in cleaned_ringing_calls {
             self.client_outgoing_calls
@@ -381,9 +355,15 @@ impl CallManager {
             }
         }
 
-        if let Some(active) = cleaned_active_call
-            && let Some(peer_id) = active.peer(client_id)
-        {
+        for active in cleaned_active_calls {
+            // Unreachable: the calls collected above all involve this client, so they all have a
+            // peer. Kept as an invariant tripwire rather than an unwrap
+            let Some(peer_id) = active.peer(client_id) else {
+                ErrorMetrics::peer_not_found();
+                tracing::warn!(call_id = ?active.call_id, "No peer found for active call");
+                continue;
+            };
+
             tracing::trace!(?peer_id, "Sending call end to peer");
             if let Err(err) = state
                 .send_message(peer_id, CallEnd::new(active.call_id, peer_id.clone()))
@@ -391,10 +371,31 @@ impl CallManager {
             {
                 tracing::warn!(?err, ?peer_id, "Failed to send call end to peer");
             }
-        } else {
-            ErrorMetrics::peer_not_found();
-            tracing::warn!("No peer found for active call");
         }
+    }
+
+    /// Removes every active call the client takes part in.
+    ///
+    /// A client is meant to be in one call at a time, but the server does not enforce it:
+    /// `start_call_attempt` only rejects a second *ringing* outgoing call, and acceptance is not
+    /// checked against the calls already running. Draining every match keeps the bookkeeping
+    /// honest if a client ends up in two anyway, because a call left behind here can never be
+    /// reached again once its other party is gone too, and its
+    /// [`CallGuard`](crate::metrics::guards::CallGuard) then keeps `vacs_calls_active` above zero
+    /// for the rest of the server's lifetime.
+    fn remove_active_calls_of(&self, client_id: &ClientId) -> Vec<ActiveCall> {
+        let mut active_calls = self.active_calls.write();
+        let call_ids: Vec<CallId> = active_calls
+            .iter()
+            .filter(|(_, active)| active.involves(client_id))
+            .map(|(call_id, _)| *call_id)
+            .collect();
+
+        call_ids
+            .into_iter()
+            .filter_map(|call_id| active_calls.remove(&call_id))
+            .map(ActiveCall::from)
+            .collect()
     }
 
     fn remove_client_incoming_call(&self, call_id: &CallId, client_id: &ClientId) {
@@ -421,5 +422,103 @@ impl CallManager {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ws::test_util::{TestSetup, create_client_info};
+    use pretty_assertions::assert_eq;
+    use test_log::test;
+    use vacs_protocol::ws::server::ServerMessage;
+
+    /// Establishes an active call from `caller` to `callee` and returns its id.
+    fn establish_call(calls: &CallManager, caller: &ClientId, callee: &ClientId) -> CallId {
+        let call_id = CallId::new();
+        calls
+            .start_call_attempt(
+                &call_id,
+                caller,
+                &CallTarget::Client(callee.clone()),
+                &HashSet::from([callee.clone()]),
+            )
+            .expect("Failed to start call attempt");
+        calls
+            .accept_call(&call_id, callee)
+            .expect("Failed to accept call");
+        call_id
+    }
+
+    #[test(tokio::test)]
+    async fn cleanup_client_calls_removes_every_active_call_of_the_client() {
+        let setup = TestSetup::new();
+        let state = setup.app_state.clone();
+        let (client1, _rx1) = setup.register_client(create_client_info(1)).await;
+        let (client2, mut rx2) = setup.register_client(create_client_info(2)).await;
+        let (client3, mut rx3) = setup.register_client(create_client_info(3)).await;
+
+        // The desktop client never gets here, but the server accepts a second call for a client
+        // that already has one, so the cleanup has to cope with it
+        establish_call(&state.calls, client1.id(), client2.id());
+        establish_call(&state.calls, client1.id(), client3.id());
+        assert_eq!(state.calls.active_call_count(), 2);
+
+        state.calls.cleanup_client_calls(&state, client1.id()).await;
+
+        assert_eq!(
+            state.calls.active_call_count(),
+            0,
+            "Disconnecting a client must not leave any of its calls active"
+        );
+        assert!(
+            matches!(rx2.try_recv(), Ok(ServerMessage::CallEnd(_))),
+            "Peer of the first call should be told the call ended"
+        );
+        assert!(
+            matches!(rx3.try_recv(), Ok(ServerMessage::CallEnd(_))),
+            "Peer of the second call should be told the call ended"
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn ending_one_call_keeps_the_clients_other_call_cleanable() {
+        let setup = TestSetup::new();
+        let state = setup.app_state.clone();
+        let (client1, _rx1) = setup.register_client(create_client_info(1)).await;
+        let (client2, _rx2) = setup.register_client(create_client_info(2)).await;
+        let (client3, _rx3) = setup.register_client(create_client_info(3)).await;
+
+        let call_1 = establish_call(&state.calls, client1.id(), client2.id());
+        establish_call(&state.calls, client1.id(), client3.id());
+
+        state
+            .calls
+            .end_active_call(&call_1, client2.id())
+            .expect("Failed to end first call");
+        assert_eq!(state.calls.active_call_count(), 1);
+
+        state.calls.cleanup_client_calls(&state, client1.id()).await;
+
+        assert_eq!(
+            state.calls.active_call_count(),
+            0,
+            "Ending one call must not make the client's other call uncleanable"
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn cleanup_client_calls_is_idempotent() {
+        let setup = TestSetup::new();
+        let state = setup.app_state.clone();
+        let (client1, _rx1) = setup.register_client(create_client_info(1)).await;
+        let (client2, _rx2) = setup.register_client(create_client_info(2)).await;
+
+        establish_call(&state.calls, client1.id(), client2.id());
+
+        state.calls.cleanup_client_calls(&state, client1.id()).await;
+        state.calls.cleanup_client_calls(&state, client2.id()).await;
+
+        assert_eq!(state.calls.active_call_count(), 0);
     }
 }

--- a/vacs-server/src/ws/application_message.rs
+++ b/vacs-server/src/ws/application_message.rs
@@ -174,6 +174,9 @@ async fn handle_call_accept(state: &AppState, client: &ClientSession, accept: Ca
     tracing::trace!("Sending call accept to source client");
     if let Err(err) = state.send_message(&ringing.caller_id, accept.clone()).await {
         tracing::warn!(?err, "Failed to send call accept to source client");
+        // The call went active the moment it was accepted, but the caller never learned about it
+        // and the answerer is about to be told the call failed, so nobody would ever end it
+        let _ = state.calls.end_active_call(call_id, answerer_id);
         send_call_error(client, call_id, CallErrorReason::SignalingFailure, None).await;
         return;
     }
@@ -559,6 +562,59 @@ mod tests {
         )
         .await;
         assert_eq!(control_flow, ControlFlow::Continue(()));
+    }
+
+    #[test(tokio::test)]
+    async fn handle_application_message_call_accept_with_unreachable_caller() {
+        let setup = TestSetup::new();
+        let (caller, caller_rx) = setup.register_client(create_client_info(1)).await;
+        let (callee, mut callee_rx) = setup.register_client(create_client_info(2)).await;
+
+        let call_id = CallId::new();
+        let control_flow = handle_application_message(
+            &setup.app_state,
+            &caller,
+            ClientMessage::CallInvite(CallInvite {
+                call_id,
+                source: shared::CallSource {
+                    client_id: caller.id().clone(),
+                    position_id: None,
+                    station_id: None,
+                },
+                target: CallTarget::Client(callee.id().clone()),
+                prio: false,
+            }),
+        )
+        .await;
+        assert_eq!(control_flow, ControlFlow::Continue(()));
+
+        // The caller's session ended between the invite and the acceptance, so the server can no
+        // longer reach it
+        drop(caller_rx);
+
+        let control_flow = handle_application_message(
+            &setup.app_state,
+            &callee,
+            ClientMessage::CallAccept(CallAccept {
+                call_id,
+                accepting_client_id: callee.id().clone(),
+            }),
+        )
+        .await;
+        assert_eq!(control_flow, ControlFlow::Continue(()));
+
+        assert_eq!(
+            setup.app_state.calls.active_call_count(),
+            0,
+            "A call the caller was never told about must not stay active"
+        );
+        let messages: Vec<_> = std::iter::from_fn(|| callee_rx.try_recv().ok()).collect();
+        assert!(
+            messages
+                .iter()
+                .any(|m| matches!(m, ServerMessage::CallError(_))),
+            "Callee should receive a call error, got {messages:?}"
+        );
     }
 
     #[test(tokio::test)]

--- a/vacs-server/tests/call.rs
+++ b/vacs-server/tests/call.rs
@@ -4,7 +4,7 @@ use vacs_protocol::vatsim::ClientId;
 use vacs_protocol::ws::client::ClientMessage;
 use vacs_protocol::ws::server::ServerMessage;
 use vacs_protocol::ws::shared::{CallId, CallTarget};
-use vacs_server::test_utils::{TestApp, setup_n_test_clients};
+use vacs_server::test_utils::{TestApp, TestClient, setup_n_test_clients};
 
 #[test(tokio::test)]
 async fn call_offer() -> anyhow::Result<()> {
@@ -349,6 +349,88 @@ async fn target_not_found() -> anyhow::Result<()> {
             call_offer_messages
         );
     }
+
+    Ok(())
+}
+
+/// Brings a call between the two clients up to the point where the server considers it active.
+async fn establish_call(
+    caller: &mut TestClient,
+    callee: &mut TestClient,
+) -> anyhow::Result<CallId> {
+    let call_id = CallId::new();
+    caller
+        .send(ClientMessage::CallInvite(
+            vacs_protocol::ws::shared::CallInvite {
+                call_id,
+                source: vacs_protocol::ws::shared::CallSource {
+                    client_id: caller.id().clone(),
+                    position_id: None,
+                    station_id: None,
+                },
+                target: CallTarget::Client(callee.id().clone()),
+                prio: false,
+            },
+        ))
+        .await?;
+
+    let invites = callee
+        .recv_until_timeout_with_filter(Duration::from_millis(100), |m| {
+            matches!(m, ServerMessage::CallInvite(_))
+        })
+        .await;
+    assert_eq!(invites.len(), 1, "callee should receive the CallInvite");
+
+    callee
+        .send(ClientMessage::CallAccept(
+            vacs_protocol::ws::shared::CallAccept {
+                call_id,
+                accepting_client_id: callee.id().clone(),
+            },
+        ))
+        .await?;
+
+    let accepts = caller
+        .recv_until_timeout_with_filter(Duration::from_millis(100), |m| {
+            matches!(m, ServerMessage::CallAccept(_))
+        })
+        .await;
+    assert_eq!(accepts.len(), 1, "caller should receive the CallAccept");
+
+    Ok(call_id)
+}
+
+#[test(tokio::test)]
+async fn disconnect_releases_every_active_call_of_the_client() -> anyhow::Result<()> {
+    let test_app = TestApp::new().await;
+    let mut clients = setup_n_test_clients(test_app.addr(), 3).await;
+
+    let mut client1 = clients.remove(0);
+    let mut client2 = clients.remove(0);
+    let mut client3 = clients.remove(0);
+
+    // The client would not do this, but nothing on the wire stops it: only a second *ringing*
+    // outgoing call is rejected, so the server has to survive a client in two calls
+    establish_call(&mut client1, &mut client2).await?;
+    establish_call(&mut client1, &mut client3).await?;
+    assert_eq!(test_app.state().calls.active_call_count(), 2);
+
+    client1.close().await;
+
+    for (name, client) in [("client2", &mut client2), ("client3", &mut client3)] {
+        let ends = client
+            .recv_until_timeout_with_filter(Duration::from_millis(500), |m| {
+                matches!(m, ServerMessage::CallEnd(_))
+            })
+            .await;
+        assert_eq!(ends.len(), 1, "{name} should be told its call ended");
+    }
+
+    assert_eq!(
+        test_app.state().calls.active_call_count(),
+        0,
+        "no call may stay active after both of its clients are gone"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
`vacs_calls_active` would get stuck at 1 and never come back down, because the gauge is RAII driven: a leaked  `ActiveCallEntry` keeps its `CallGuard` alive for the rest of the process.
Proper cleanup of active calls from a single source of truth as well as improved error handling should solve this metric bug.