### PR TITLE
fix(vacs-client): register Wayland portal shortcuts reliably and resolve the radio PTT fallback at runtime

### DIFF
--- a/vacs-client/src/app/state.rs
+++ b/vacs-client/src/app/state.rs
@@ -55,7 +55,7 @@ pub struct AppStateInner {
 pub type AppState = TokioMutex<AppStateInner>;
 
 impl AppStateInner {
-    pub async fn new(app: &AppHandle) -> Result<Self, StartupError> {
+    pub fn new(app: &AppHandle) -> Result<Self, StartupError> {
         let config_dir = app
             .path()
             .app_config_dir()
@@ -76,16 +76,13 @@ impl AppStateInner {
                 AudioManager::new(app.clone(), &config.audio)
                     .map_startup_err(StartupError::Audio)?,
             )),
-            keybind_engine: Arc::new(TokioRwLock::new(
-                KeybindEngine::new(
-                    app.clone(),
-                    &config.client.transmit_config,
-                    &config.client.keybinds,
-                    config.client.radio.integration.is_some(),
-                    shutdown_token.child_token(),
-                )
-                .await,
-            )),
+            keybind_engine: Arc::new(TokioRwLock::new(KeybindEngine::new(
+                app.clone(),
+                &config.client.transmit_config,
+                &config.client.keybinds,
+                config.client.radio.integration.is_some(),
+                shutdown_token.child_token(),
+            ))),
             playback_recorder: Arc::new(RwLock::new(None)),
             radio: Arc::new(RwLock::new(None)),
             shutdown_token,

--- a/vacs-client/src/keybinds.rs
+++ b/vacs-client/src/keybinds.rs
@@ -338,28 +338,17 @@ impl TransmitConfig {
     }
 
     /// The trigger that drives radio TX, if any.
-    pub async fn active_radio_trigger(&self, enabled: bool) -> Option<Trigger> {
+    pub fn active_radio_trigger(&self, enabled: bool) -> Option<Trigger> {
         if !enabled {
             return None;
         }
 
         #[cfg(target_os = "linux")]
         if matches!(Platform::get(), Platform::LinuxWayland) {
-            use crate::keybinds::runtime;
-
             // See active_call_trigger: portal activations replace keyboard codes.
             let portal = match self.call_mic_mode {
-                CallMicMode::VoiceActivation => Some(PortalAction::RadioPushToTalk),
-                CallMicMode::PushToTalk => {
-                    if runtime::is_portal_shortcut_bound(runtime::PortalShortcutId::RadioPushToTalk)
-                        .await
-                    {
-                        Some(PortalAction::RadioPushToTalk)
-                    } else {
-                        // No dedicated radio shortcut bound at the OS level: radio TX
-                        // follows the call PTT shortcut instead.
-                        Some(PortalAction::PushToTalk)
-                    }
+                CallMicMode::VoiceActivation | CallMicMode::PushToTalk => {
+                    Some(PortalAction::RadioPushToTalk)
                 }
                 CallMicMode::PushToMute => Some(PortalAction::PushToMute),
             };
@@ -372,6 +361,30 @@ impl TransmitConfig {
         }
 
         self.configured_radio_input().map(Trigger::Input)
+    }
+
+    /// Whether radio TX falls back to the call trigger while no dedicated radio
+    /// shortcut is bound at the OS level.
+    ///
+    /// Only the Wayland portal has this ambiguity: the radio shortcut is
+    /// registered whether or not the user assigned a key to it, so "is there a
+    /// dedicated radio key" cannot be answered from configuration alone. The
+    /// answer also changes while the app runs, whenever the user edits the
+    /// binding in their desktop environment, so the engine resolves it from the
+    /// listener's live view rather than caching it here.
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+    pub fn radio_falls_back_to_call(&self, enabled: bool) -> bool {
+        #[cfg(target_os = "linux")]
+        if enabled
+            && matches!(Platform::get(), Platform::LinuxWayland)
+            && matches!(self.call_mic_mode, CallMicMode::PushToTalk)
+        {
+            // A configured joystick button replaces the portal shortcut, so
+            // there is nothing to fall back from.
+            return !matches!(self.configured_radio_input(), Some(InputCode::Button(_)));
+        }
+
+        false
     }
 }
 
@@ -619,6 +632,77 @@ mod tests {
     }
 
     #[test]
+    fn radio_never_falls_back_to_call_without_radio_integration() {
+        let config = TransmitConfig {
+            call_mic_mode: CallMicMode::PushToTalk,
+            ..Default::default()
+        };
+
+        assert!(!config.radio_falls_back_to_call(false));
+    }
+
+    #[test]
+    fn radio_only_falls_back_to_call_for_wayland_push_to_talk() {
+        let ptt = TransmitConfig {
+            call_mic_mode: CallMicMode::PushToTalk,
+            ..Default::default()
+        };
+
+        // Off Wayland the radio binding is known from configuration alone, so
+        // the fallback is folded into active_radio_trigger instead.
+        assert_eq!(ptt.radio_falls_back_to_call(true), running_on_wayland());
+
+        for mode in [CallMicMode::PushToMute, CallMicMode::VoiceActivation] {
+            let config = TransmitConfig {
+                call_mic_mode: mode,
+                ..Default::default()
+            };
+            assert!(
+                !config.radio_falls_back_to_call(true),
+                "{mode:?} has an unambiguous radio trigger"
+            );
+        }
+    }
+
+    #[test]
+    fn configured_joystick_button_suppresses_the_radio_fallback() {
+        let config = TransmitConfig {
+            call_mic_mode: CallMicMode::PushToTalk,
+            radio_push_to_talk: Some(button("guid", 4, None)),
+            ..Default::default()
+        };
+
+        // The button replaces the portal shortcut outright, so there is no
+        // unbound portal shortcut left to fall back from.
+        assert!(!config.radio_falls_back_to_call(true));
+        assert_eq!(
+            config.active_radio_trigger(true),
+            Some(Trigger::Input(button("guid", 4, None)))
+        );
+    }
+
+    #[test]
+    fn wayland_radio_trigger_is_always_the_dedicated_portal_action() {
+        if !running_on_wayland() {
+            return;
+        }
+
+        // Unlike the keyboard bindings, which the portal owns, the trigger no
+        // longer depends on whether a key is currently assigned to it: the
+        // engine resolves the fallback from the listener at runtime.
+        let config = TransmitConfig {
+            call_mic_mode: CallMicMode::PushToTalk,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.active_radio_trigger(true),
+            Some(Trigger::Portal(PortalAction::RadioPushToTalk))
+        );
+        assert!(config.radio_falls_back_to_call(true));
+    }
+
+    #[test]
     fn active_triggers_in_push_to_mute_mode_follow_ptm_binding() {
         // Only run the non-Wayland branch deterministically; the Wayland
         // composition itself is covered by the compose_wayland_trigger tests.
@@ -637,10 +721,7 @@ mod tests {
 
         let expected = Some(Trigger::Input(button("guid", 1, None)));
         assert_eq!(config.active_call_trigger(), expected);
-        assert_eq!(
-            tauri::async_runtime::block_on(config.active_radio_trigger(true)),
-            expected
-        );
+        assert_eq!(config.active_radio_trigger(true), expected);
     }
 
     #[test]
@@ -661,7 +742,7 @@ mod tests {
 
         assert_eq!(config.active_call_trigger(), None);
         assert_eq!(
-            tauri::async_runtime::block_on(config.active_radio_trigger(true)),
+            config.active_radio_trigger(true),
             Some(Trigger::Input(button("guid", 2, None)))
         );
     }
@@ -686,12 +767,9 @@ mod tests {
         );
 
         // No dedicated radio binding: radio TX follows the call PTT binding
-        let radio = tauri::async_runtime::block_on(config.active_radio_trigger(true));
+        let radio = config.active_radio_trigger(true);
         assert_eq!(radio, Some(Trigger::Input(button("guid", 0, None))));
 
-        assert_eq!(
-            tauri::async_runtime::block_on(config.active_radio_trigger(false)),
-            None
-        );
+        assert_eq!(config.active_radio_trigger(false), None);
     }
 }

--- a/vacs-client/src/keybinds.rs
+++ b/vacs-client/src/keybinds.rs
@@ -337,7 +337,19 @@ impl TransmitConfig {
         }
     }
 
-    /// The trigger that drives radio TX, if any.
+    /// The dedicated trigger for radio TX, if any.
+    ///
+    /// Off Wayland this is also the effective trigger: `configured_radio_input`
+    /// already folds in the "no dedicated binding, follow the call PTT binding"
+    /// case, so the result equals `active_call_trigger` when that applies.
+    ///
+    /// On Wayland with a keyboard binding it is only the dedicated portal
+    /// action. Whether radio TX is following the call trigger instead is a
+    /// runtime question, because the portal registers the radio shortcut
+    /// whether or not a key is assigned to it. `radio_falls_back_to_call`
+    /// reports whether the configuration allows that, and the engine resolves
+    /// the live answer. Do not read this as "the trigger that keys the radio
+    /// right now".
     pub fn active_radio_trigger(&self, enabled: bool) -> Option<Trigger> {
         if !enabled {
             return None;

--- a/vacs-client/src/keybinds/commands.rs
+++ b/vacs-client/src/keybinds/commands.rs
@@ -399,12 +399,23 @@ pub fn keybinds_open_system_shortcuts_settings() -> Result<(), Error> {
 #[tauri::command]
 #[vacs_macros::log_err]
 pub async fn keybinds_is_portal_shortcut_bound(
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] keybind_engine: State<
+        '_,
+        KeybindEngineHandle,
+    >,
     #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] keybind: Keybind,
 ) -> Result<bool, Error> {
     #[cfg(target_os = "linux")]
     {
-        use crate::keybinds::runtime;
-        return Ok(runtime::is_portal_shortcut_bound(keybind.into()).await);
+        // Reads the listener's live view of the portal bindings rather than
+        // opening a throwaway portal session per query: the extra sessions are
+        // leak-prone, and on portal backends that only report shortcuts after
+        // BindShortcuts they always came back empty.
+        return Ok(keybind_engine
+            .read()
+            .await
+            .get_external_binding(keybind)
+            .is_some());
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/vacs-client/src/keybinds/commands.rs
+++ b/vacs-client/src/keybinds/commands.rs
@@ -75,7 +75,7 @@ pub async fn keybinds_set_transmit_config(
             &transmit_config.radio_push_to_talk,
         ])?;
 
-        state.config.client.radio.validate(&transmit_config).await?;
+        state.config.client.radio.validate(&transmit_config)?;
 
         keybind_engine
             .write()

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -645,10 +645,6 @@ impl Drop for KeybindEngine {
     }
 }
 
-/// Whether a dedicated radio PTT key is bound at the OS level.
-///
-/// Only ever true on Wayland, where the listener tracks the portal's shortcuts
-/// and updates them as the user edits their desktop environment settings.
 /// Re-resolves whether radio TX follows the call trigger, from the listener's
 /// live view of the OS level bindings.
 ///

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -37,6 +37,12 @@ pub struct KeybindEngine {
     rx_task: Option<JoinHandle<()>>,
     shutdown_token: CancellationToken,
     stop_token: Option<CancellationToken>,
+    /// Whether this configuration lets radio TX fall back to the call trigger
+    /// when no dedicated radio shortcut is bound at the OS level.
+    radio_portal_fallback: bool,
+    /// Whether that fallback is active right now. Resolved from the listener's
+    /// live bindings, which change while the app runs.
+    radio_follows_call: Arc<AtomicBool>,
     call_pressed: Arc<AtomicBool>,
     radio_pressed: Arc<AtomicBool>,
     call_active: Arc<AtomicBool>,
@@ -58,9 +64,7 @@ impl KeybindEngine {
         Self {
             call_mic_mode: transmit_config.call_mic_mode,
             call_trigger: transmit_config.active_call_trigger(),
-            radio_trigger: transmit_config
-                .active_radio_trigger(radio_integration_enabled)
-                .await,
+            radio_trigger: transmit_config.active_radio_trigger(radio_integration_enabled),
             accept_call_trigger: Self::select_accept_call_trigger(call_control_config),
             end_call_trigger: Self::select_end_call_trigger(call_control_config),
             toggle_radio_prio_trigger: Self::select_toggle_radio_prio_trigger(call_control_config),
@@ -69,6 +73,11 @@ impl KeybindEngine {
             rx_task: None,
             shutdown_token,
             stop_token: None,
+            radio_portal_fallback: transmit_config
+                .radio_falls_back_to_call(radio_integration_enabled),
+            radio_follows_call: Arc::new(AtomicBool::new(
+                transmit_config.radio_falls_back_to_call(radio_integration_enabled),
+            )),
             call_pressed: Arc::new(AtomicBool::new(false)),
             radio_pressed: Arc::new(AtomicBool::new(false)),
             call_active: Arc::new(AtomicBool::new(false)),
@@ -160,9 +169,41 @@ impl KeybindEngine {
             );
         }
 
+        self.refresh_radio_follows_call();
         self.spawn_rx_loop(key_event_rx);
 
         Ok(())
+    }
+
+    /// Re-resolves the radio fallback from the listener's current bindings.
+    ///
+    /// Never re-resolves while a key is held: flipping the fallback mid-press
+    /// would classify the release differently from the press and leave the
+    /// radio keyed.
+    fn refresh_radio_follows_call(&self) {
+        if self.call_pressed.load(Ordering::Relaxed) || self.radio_pressed.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let follows =
+            self.radio_portal_fallback && !radio_shortcut_bound(self.listener.read().as_ref());
+        if self.radio_follows_call.swap(follows, Ordering::Relaxed) != follows {
+            log::debug!(
+                "Radio TX now follows the {} trigger",
+                if follows { "call" } else { "radio" }
+            );
+        }
+    }
+
+    /// Whether radio TX and the call MIC action share one trigger, either
+    /// because they are configured to the same input or because the portal
+    /// fallback is active.
+    fn radio_shares_call_trigger(&self) -> bool {
+        self.refresh_radio_follows_call();
+
+        self.radio_trigger.is_some()
+            && (self.radio_trigger == self.call_trigger
+                || self.radio_follows_call.load(Ordering::Relaxed))
     }
 
     pub fn stop(&mut self) {
@@ -201,9 +242,11 @@ impl KeybindEngine {
 
         self.call_mic_mode = transmit_config.call_mic_mode;
         self.call_trigger = transmit_config.active_call_trigger();
-        self.radio_trigger = transmit_config
-            .active_radio_trigger(radio_integration_enabled)
-            .await;
+        self.radio_trigger = transmit_config.active_radio_trigger(radio_integration_enabled);
+        self.radio_portal_fallback =
+            transmit_config.radio_falls_back_to_call(radio_integration_enabled);
+        self.radio_follows_call
+            .store(self.radio_portal_fallback, Ordering::Relaxed);
 
         self.accept_call_trigger = Self::select_accept_call_trigger(keybinds_config);
         self.end_call_trigger = Self::select_end_call_trigger(keybinds_config);
@@ -220,8 +263,7 @@ impl KeybindEngine {
         self.call_active.store(active, Ordering::Relaxed);
 
         if active {
-            if self.radio_trigger.is_some()
-                && self.radio_trigger == self.call_trigger
+            if self.radio_shares_call_trigger()
                 && self.radio_pressed.load(Ordering::Relaxed)
                 && self.radio_transmitting.load(Ordering::Relaxed)
                 && !self.radio_prio.load(Ordering::Relaxed)
@@ -283,7 +325,7 @@ impl KeybindEngine {
         let call_pressed = self.call_pressed.load(Ordering::Relaxed);
         let radio_pressed = self.radio_pressed.load(Ordering::Relaxed);
         let radio_prio = self.radio_prio.load(Ordering::Relaxed);
-        let separate_keys = self.radio_trigger.is_some() && self.radio_trigger != self.call_trigger;
+        let separate_keys = self.radio_trigger.is_some() && !self.radio_shares_call_trigger();
         match self.call_mic_mode {
             CallMicMode::VoiceActivation => false,
             CallMicMode::PushToTalk => {
@@ -439,6 +481,12 @@ impl KeybindEngine {
             .clone()
             .unwrap_or(self.shutdown_token.child_token());
         let radio_handle = self.app.state::<RadioHandle>().inner().clone();
+        let radio_portal_fallback = self.radio_portal_fallback;
+        let radio_follows_call = self.radio_follows_call.clone();
+        // The listener outlives this task: `stop()` aborts the task before it
+        // drops the listener, and `start()` installs a new one before spawning
+        // the replacement.
+        let listener = self.listener.read().clone();
         let call_pressed = self.call_pressed.clone();
         let radio_pressed = self.radio_pressed.clone();
         let call_active = self.call_active.clone();
@@ -462,8 +510,19 @@ impl KeybindEngine {
                             Self::handle_call_control_event(&app, &event.trigger, accept_call.as_ref(), end_call.as_ref(), toggle_radio_prio.as_ref()).await;
                         }
 
+                        // Re-resolve the portal fallback only between press cycles: flipping it
+                        // while a key is held would classify the release differently from the
+                        // press and leave the radio keyed.
+                        if radio_portal_fallback
+                            && !call_pressed.load(Ordering::Relaxed)
+                            && !radio_pressed.load(Ordering::Relaxed)
+                        {
+                            radio_follows_call.store(!radio_shortcut_bound(listener.as_ref()), Ordering::Relaxed);
+                        }
+
                         let is_call_key = call_trigger.as_ref() == Some(&event.trigger);
-                        let is_radio_key = radio_trigger.as_ref() == Some(&event.trigger);
+                        let is_radio_key = radio_trigger.as_ref() == Some(&event.trigger)
+                            || (is_call_key && radio_follows_call.load(Ordering::Relaxed));
 
                         if !is_call_key && !is_radio_key { continue; }
 
@@ -585,4 +644,14 @@ impl Drop for KeybindEngine {
     fn drop(&mut self) {
         self.stop();
     }
+}
+
+/// Whether a dedicated radio PTT key is bound at the OS level.
+///
+/// Only ever true on Wayland, where the listener tracks the portal's shortcuts
+/// and updates them as the user edits their desktop environment settings.
+fn radio_shortcut_bound(listener: Option<&DynKeybindListener>) -> bool {
+    listener
+        .and_then(|l| l.get_external_binding(Keybind::RadioPushToTalk))
+        .is_some()
 }

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -4,7 +4,9 @@ use crate::app::state::webrtc::AppStateWebrtcExt;
 use crate::audio::manager::AudioManagerHandle;
 use crate::error::Error;
 use crate::keybinds::joystick::JoystickServiceHandle;
-use crate::keybinds::runtime::{DynKeybindListener, KeybindListener, PlatformListener};
+use crate::keybinds::runtime::{
+    DynKeybindListener, KeybindListener, PlatformListener, WeakKeybindListener,
+};
 use crate::keybinds::{
     CallMicMode, InputCode, KeyEvent, Keybind, KeybindsConfig, TransmitConfig, Trigger,
 };
@@ -177,7 +179,7 @@ impl KeybindEngine {
 
     fn refresh_radio_follows_call(&self) {
         refresh_radio_follows_call(
-            self.listener.read().as_ref(),
+            self.listener.read().as_ref().map(Arc::downgrade).as_ref(),
             self.radio_portal_fallback,
             &self.radio_follows_call,
             &self.call_pressed,
@@ -502,7 +504,7 @@ impl KeybindEngine {
                         }
 
                         refresh_radio_follows_call(
-                            listener.as_ref().and_then(|l| l.upgrade()).as_ref(),
+                            listener.as_ref(),
                             radio_portal_fallback,
                             &radio_follows_call,
                             &call_pressed,
@@ -647,12 +649,6 @@ impl Drop for KeybindEngine {
 ///
 /// Only ever true on Wayland, where the listener tracks the portal's shortcuts
 /// and updates them as the user edits their desktop environment settings.
-fn radio_shortcut_bound(listener: Option<&DynKeybindListener>) -> bool {
-    listener
-        .and_then(|l| l.get_external_binding(Keybind::RadioPushToTalk))
-        .is_some()
-}
-
 /// Re-resolves whether radio TX follows the call trigger, from the listener's
 /// live view of the OS level bindings.
 ///
@@ -660,18 +656,26 @@ fn radio_shortcut_bound(listener: Option<&DynKeybindListener>) -> bool {
 /// classify the release differently from the press and leave the radio keyed.
 /// Both the engine and its event loop go through here so that invariant, and
 /// the log line reporting a flip, cannot drift apart.
+///
+/// Runs on every key event, so the two cheap guards come first and the listener
+/// is only resolved once they pass.
 fn refresh_radio_follows_call(
-    listener: Option<&DynKeybindListener>,
+    listener: Option<&WeakKeybindListener>,
     fallback: bool,
     follows_call: &AtomicBool,
     call_pressed: &AtomicBool,
     radio_pressed: &AtomicBool,
 ) {
-    if call_pressed.load(Ordering::Relaxed) || radio_pressed.load(Ordering::Relaxed) {
+    // Without the portal fallback there is nothing to resolve: `follows_call` is
+    // false from construction and no binding can change that.
+    if !fallback || call_pressed.load(Ordering::Relaxed) || radio_pressed.load(Ordering::Relaxed) {
         return;
     }
 
-    let follows = fallback && !radio_shortcut_bound(listener);
+    let follows = !listener
+        .and_then(|l| l.upgrade())
+        .is_some_and(|l| l.has_external_binding(Keybind::RadioPushToTalk));
+
     if follows_call.swap(follows, Ordering::Relaxed) != follows {
         log::debug!(
             "Radio TX now follows the {} trigger",

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -63,6 +63,9 @@ impl KeybindEngine {
         radio_integration_enabled: bool,
         shutdown_token: CancellationToken,
     ) -> Self {
+        let radio_portal_fallback =
+            transmit_config.radio_falls_back_to_call(radio_integration_enabled);
+
         Self {
             call_mic_mode: transmit_config.call_mic_mode,
             call_trigger: transmit_config.active_call_trigger(),
@@ -75,11 +78,8 @@ impl KeybindEngine {
             rx_task: None,
             shutdown_token,
             stop_token: None,
-            radio_portal_fallback: transmit_config
-                .radio_falls_back_to_call(radio_integration_enabled),
-            radio_follows_call: Arc::new(AtomicBool::new(
-                transmit_config.radio_falls_back_to_call(radio_integration_enabled),
-            )),
+            radio_portal_fallback,
+            radio_follows_call: Arc::new(AtomicBool::new(radio_portal_fallback)),
             call_pressed: Arc::new(AtomicBool::new(false)),
             radio_pressed: Arc::new(AtomicBool::new(false)),
             call_active: Arc::new(AtomicBool::new(false)),

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -511,17 +511,12 @@ impl KeybindEngine {
                             &radio_pressed,
                         );
 
-                        let is_call_key = call_trigger.as_ref() == Some(&event.trigger);
-                        // Exactly one of the two can be the radio key. While the fallback is
-                        // active the dedicated shortcut is unbound, so also honoring it would
-                        // let a momentarily stale fallback count one press twice against the
-                        // shared `radio_pressed` flag, swallow the matching release and leave
-                        // the transmitter keyed.
-                        let is_radio_key = if radio_follows_call.load(Ordering::Relaxed) {
-                            is_call_key
-                        } else {
-                            radio_trigger.as_ref() == Some(&event.trigger)
-                        };
+                        let (is_call_key, is_radio_key) = classify_trigger(
+                            &event.trigger,
+                            call_trigger.as_ref(),
+                            radio_trigger.as_ref(),
+                            radio_follows_call.load(Ordering::Relaxed),
+                        );
 
                         if !is_call_key && !is_radio_key { continue; }
 
@@ -645,6 +640,30 @@ impl Drop for KeybindEngine {
     }
 }
 
+/// Classifies an incoming trigger as the call key, the radio key, both or neither.
+///
+/// Exactly one thing can be the radio key. While the fallback is active the
+/// dedicated shortcut is unbound, so also honoring it would let a momentarily
+/// stale fallback count one press twice against the engine's shared
+/// `radio_pressed` flag, swallow the matching release and leave the transmitter
+/// keyed. A single trigger configured for both still classifies as both, which
+/// is how the non-portal platforms express "radio follows the call key".
+fn classify_trigger(
+    trigger: &Trigger,
+    call_trigger: Option<&Trigger>,
+    radio_trigger: Option<&Trigger>,
+    radio_follows_call: bool,
+) -> (bool, bool) {
+    let is_call_key = call_trigger == Some(trigger);
+    let is_radio_key = if radio_follows_call {
+        is_call_key
+    } else {
+        radio_trigger == Some(trigger)
+    };
+
+    (is_call_key, is_radio_key)
+}
+
 /// Re-resolves whether radio TX follows the call trigger, from the listener's
 /// live view of the OS level bindings.
 ///
@@ -676,6 +695,192 @@ fn refresh_radio_follows_call(
         log::debug!(
             "Radio TX now follows the {} trigger",
             if follows { "call" } else { "radio" }
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keybinds::{KeybindsError, PortalAction, TransmitConfig};
+    use tokio::sync::mpsc::UnboundedSender;
+
+    /// Stands in for a platform listener so the resolution can be exercised
+    /// without a portal, an `AppHandle` or a running event loop.
+    #[derive(Debug)]
+    struct FakeListener {
+        radio_bound: bool,
+    }
+
+    impl KeybindListener for FakeListener {
+        async fn start(_key_event_tx: UnboundedSender<KeyEvent>) -> Result<Self, KeybindsError> {
+            unreachable!("test listeners are constructed directly")
+        }
+
+        fn has_external_binding(&self, keybind: Keybind) -> bool {
+            self.radio_bound && keybind == Keybind::RadioPushToTalk
+        }
+    }
+
+    fn listener(radio_bound: bool) -> DynKeybindListener {
+        Arc::new(FakeListener { radio_bound })
+    }
+
+    struct Fixture {
+        follows: AtomicBool,
+        call_pressed: AtomicBool,
+        radio_pressed: AtomicBool,
+    }
+
+    impl Fixture {
+        fn new(follows: bool) -> Self {
+            Self {
+                follows: AtomicBool::new(follows),
+                call_pressed: AtomicBool::new(false),
+                radio_pressed: AtomicBool::new(false),
+            }
+        }
+
+        fn refresh(&self, listener: Option<&WeakKeybindListener>, fallback: bool) -> bool {
+            refresh_radio_follows_call(
+                listener,
+                fallback,
+                &self.follows,
+                &self.call_pressed,
+                &self.radio_pressed,
+            );
+            self.follows.load(Ordering::Relaxed)
+        }
+    }
+
+    fn call() -> Trigger {
+        Trigger::Portal(PortalAction::PushToTalk)
+    }
+
+    fn radio() -> Trigger {
+        Trigger::Portal(PortalAction::RadioPushToTalk)
+    }
+
+    #[test]
+    fn radio_follows_the_call_key_while_no_dedicated_shortcut_is_bound() {
+        let listener = listener(false);
+        let fixture = Fixture::new(false);
+
+        assert!(fixture.refresh(Some(&Arc::downgrade(&listener)), true));
+    }
+
+    #[test]
+    fn radio_stops_following_the_call_key_once_a_shortcut_is_bound() {
+        let listener = listener(true);
+        let fixture = Fixture::new(true);
+
+        assert!(!fixture.refresh(Some(&Arc::downgrade(&listener)), true));
+    }
+
+    #[test]
+    fn configs_without_the_portal_fallback_never_resolve() {
+        // A bound shortcut must not flip a config that has no fallback rule, so
+        // every non-Wayland platform keeps its configured triggers verbatim.
+        let listener = listener(false);
+        let fixture = Fixture::new(false);
+
+        assert!(!fixture.refresh(Some(&Arc::downgrade(&listener)), false));
+    }
+
+    #[test]
+    fn the_fallback_never_flips_while_a_key_is_held() {
+        // Flipping mid-press would classify the release differently from the
+        // press and leave the radio keyed.
+        let listener = listener(true);
+        let weak = Arc::downgrade(&listener);
+
+        let held_call = Fixture::new(true);
+        held_call.call_pressed.store(true, Ordering::Relaxed);
+        assert!(held_call.refresh(Some(&weak), true), "call key held");
+
+        let held_radio = Fixture::new(true);
+        held_radio.radio_pressed.store(true, Ordering::Relaxed);
+        assert!(held_radio.refresh(Some(&weak), true), "radio key held");
+    }
+
+    #[test]
+    fn a_dropped_listener_reads_as_unbound() {
+        // `stop()` takes the listener while the event loop still holds its weak
+        // handle; resolving through a dangling one must not panic.
+        let weak = Arc::downgrade(&listener(true));
+        let fixture = Fixture::new(false);
+
+        assert!(fixture.refresh(Some(&weak), true));
+        assert!(fixture.refresh(None, true));
+    }
+
+    #[test]
+    fn separate_triggers_classify_independently() {
+        assert_eq!(
+            classify_trigger(&radio(), Some(&call()), Some(&radio()), false),
+            (false, true)
+        );
+        assert_eq!(
+            classify_trigger(&call(), Some(&call()), Some(&radio()), false),
+            (true, false)
+        );
+    }
+
+    #[test]
+    fn the_fallback_makes_the_call_key_the_radio_key() {
+        assert_eq!(
+            classify_trigger(&call(), Some(&call()), Some(&radio()), true),
+            (true, true)
+        );
+    }
+
+    #[test]
+    fn a_stale_fallback_never_double_counts_the_dedicated_trigger() {
+        // Regression: classifying the dedicated shortcut as a radio key while the
+        // fallback was still active let one press take `radio_pressed` twice, so
+        // the release was swallowed and the transmitter stayed keyed.
+        assert_eq!(
+            classify_trigger(&radio(), Some(&call()), Some(&radio()), true),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn one_trigger_bound_to_both_classifies_as_both() {
+        assert_eq!(
+            classify_trigger(&call(), Some(&call()), Some(&call()), false),
+            (true, true)
+        );
+    }
+
+    #[test]
+    fn an_unrelated_trigger_classifies_as_neither() {
+        let other = Trigger::Portal(PortalAction::CallControl);
+
+        assert_eq!(
+            classify_trigger(&other, Some(&call()), Some(&radio()), false),
+            (false, false)
+        );
+        assert_eq!(
+            classify_trigger(&other, Some(&call()), Some(&radio()), true),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn the_engine_starts_the_fallback_where_the_config_puts_it() {
+        // The atomic must agree with the config before any listener exists, or
+        // the first press resolves against a value the config never chose.
+        let config = TransmitConfig {
+            call_mic_mode: CallMicMode::PushToTalk,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.radio_falls_back_to_call(true),
+            Fixture::new(config.radio_falls_back_to_call(true))
+                .follows
+                .load(Ordering::Relaxed)
         );
     }
 }

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -175,24 +175,14 @@ impl KeybindEngine {
         Ok(())
     }
 
-    /// Re-resolves the radio fallback from the listener's current bindings.
-    ///
-    /// Never re-resolves while a key is held: flipping the fallback mid-press
-    /// would classify the release differently from the press and leave the
-    /// radio keyed.
     fn refresh_radio_follows_call(&self) {
-        if self.call_pressed.load(Ordering::Relaxed) || self.radio_pressed.load(Ordering::Relaxed) {
-            return;
-        }
-
-        let follows =
-            self.radio_portal_fallback && !radio_shortcut_bound(self.listener.read().as_ref());
-        if self.radio_follows_call.swap(follows, Ordering::Relaxed) != follows {
-            log::debug!(
-                "Radio TX now follows the {} trigger",
-                if follows { "call" } else { "radio" }
-            );
-        }
+        refresh_radio_follows_call(
+            self.listener.read().as_ref(),
+            self.radio_portal_fallback,
+            &self.radio_follows_call,
+            &self.call_pressed,
+            &self.radio_pressed,
+        );
     }
 
     /// Whether radio TX and the call MIC action share one trigger, either
@@ -510,15 +500,13 @@ impl KeybindEngine {
                             Self::handle_call_control_event(&app, &event.trigger, accept_call.as_ref(), end_call.as_ref(), toggle_radio_prio.as_ref()).await;
                         }
 
-                        // Re-resolve the portal fallback only between press cycles: flipping it
-                        // while a key is held would classify the release differently from the
-                        // press and leave the radio keyed.
-                        if radio_portal_fallback
-                            && !call_pressed.load(Ordering::Relaxed)
-                            && !radio_pressed.load(Ordering::Relaxed)
-                        {
-                            radio_follows_call.store(!radio_shortcut_bound(listener.as_ref()), Ordering::Relaxed);
-                        }
+                        refresh_radio_follows_call(
+                            listener.as_ref(),
+                            radio_portal_fallback,
+                            &radio_follows_call,
+                            &call_pressed,
+                            &radio_pressed,
+                        );
 
                         let is_call_key = call_trigger.as_ref() == Some(&event.trigger);
                         let is_radio_key = radio_trigger.as_ref() == Some(&event.trigger)
@@ -654,4 +642,31 @@ fn radio_shortcut_bound(listener: Option<&DynKeybindListener>) -> bool {
     listener
         .and_then(|l| l.get_external_binding(Keybind::RadioPushToTalk))
         .is_some()
+}
+
+/// Re-resolves whether radio TX follows the call trigger, from the listener's
+/// live view of the OS level bindings.
+///
+/// Never re-resolves while a key is held: flipping the fallback mid-press would
+/// classify the release differently from the press and leave the radio keyed.
+/// Both the engine and its event loop go through here so that invariant, and
+/// the log line reporting a flip, cannot drift apart.
+fn refresh_radio_follows_call(
+    listener: Option<&DynKeybindListener>,
+    fallback: bool,
+    follows_call: &AtomicBool,
+    call_pressed: &AtomicBool,
+    radio_pressed: &AtomicBool,
+) {
+    if call_pressed.load(Ordering::Relaxed) || radio_pressed.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let follows = fallback && !radio_shortcut_bound(listener);
+    if follows_call.swap(follows, Ordering::Relaxed) != follows {
+        log::debug!(
+            "Radio TX now follows the {} trigger",
+            if follows { "call" } else { "radio" }
+        );
+    }
 }

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -190,9 +190,12 @@ impl KeybindEngine {
     /// Whether radio TX and the call MIC action share one trigger, either
     /// because they are configured to the same input or because the portal
     /// fallback is active.
+    ///
+    /// Reads the fallback without re-resolving it. Callers run on other tasks,
+    /// and the event loop classifies a press before it marks the key as held, so
+    /// a refresh from here could flip the fallback inside that gap and have the
+    /// release classified differently from its press.
     fn radio_shares_call_trigger(&self) -> bool {
-        self.refresh_radio_follows_call();
-
         self.radio_trigger.is_some()
             && (self.radio_trigger == self.call_trigger
                 || self.radio_follows_call.load(Ordering::Relaxed))
@@ -669,8 +672,9 @@ fn classify_trigger(
 ///
 /// Never re-resolves while a key is held: flipping the fallback mid-press would
 /// classify the release differently from the press and leave the radio keyed.
-/// Both the engine and its event loop go through here so that invariant, and
-/// the log line reporting a flip, cannot drift apart.
+/// Only ever called from `start()` and from the event loop, which never overlap,
+/// so the held-key check and the write it guards cannot interleave with another
+/// writer.
 ///
 /// Runs on every key event, so the two cheap guards come first and the listener
 /// is only resolved once they pass.
@@ -702,7 +706,7 @@ fn refresh_radio_follows_call(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::keybinds::{KeybindsError, PortalAction, TransmitConfig};
+    use crate::keybinds::{KeybindsError, PortalAction};
     use tokio::sync::mpsc::UnboundedSender;
 
     /// Stands in for a platform listener so the resolution can be exercised
@@ -864,23 +868,6 @@ mod tests {
         assert_eq!(
             classify_trigger(&other, Some(&call()), Some(&radio()), true),
             (false, false)
-        );
-    }
-
-    #[test]
-    fn the_engine_starts_the_fallback_where_the_config_puts_it() {
-        // The atomic must agree with the config before any listener exists, or
-        // the first press resolves against a value the config never chose.
-        let config = TransmitConfig {
-            call_mic_mode: CallMicMode::PushToTalk,
-            ..Default::default()
-        };
-
-        assert_eq!(
-            config.radio_falls_back_to_call(true),
-            Fixture::new(config.radio_falls_back_to_call(true))
-                .follows
-                .load(Ordering::Relaxed)
         );
     }
 }

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -56,7 +56,7 @@ pub struct KeybindEngine {
 pub type KeybindEngineHandle = Arc<TokioRwLock<KeybindEngine>>;
 
 impl KeybindEngine {
-    pub async fn new(
+    pub fn new(
         app: AppHandle,
         transmit_config: &TransmitConfig,
         call_control_config: &KeybindsConfig,

--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -473,10 +473,11 @@ impl KeybindEngine {
         let radio_handle = self.app.state::<RadioHandle>().inner().clone();
         let radio_portal_fallback = self.radio_portal_fallback;
         let radio_follows_call = self.radio_follows_call.clone();
-        // The listener outlives this task: `stop()` aborts the task before it
-        // drops the listener, and `start()` installs a new one before spawning
-        // the replacement.
-        let listener = self.listener.read().clone();
+        // Weak, not owning: `stop()` drops the engine's handle before aborting
+        // this task, and an owning clone here would keep the old listener (and
+        // its portal session) alive until the runtime reclaims the aborted
+        // task, overlapping it with the session `start()` opens next.
+        let listener = self.listener.read().as_ref().map(Arc::downgrade);
         let call_pressed = self.call_pressed.clone();
         let radio_pressed = self.radio_pressed.clone();
         let call_active = self.call_active.clone();
@@ -501,7 +502,7 @@ impl KeybindEngine {
                         }
 
                         refresh_radio_follows_call(
-                            listener.as_ref(),
+                            listener.as_ref().and_then(|l| l.upgrade()).as_ref(),
                             radio_portal_fallback,
                             &radio_follows_call,
                             &call_pressed,
@@ -509,8 +510,16 @@ impl KeybindEngine {
                         );
 
                         let is_call_key = call_trigger.as_ref() == Some(&event.trigger);
-                        let is_radio_key = radio_trigger.as_ref() == Some(&event.trigger)
-                            || (is_call_key && radio_follows_call.load(Ordering::Relaxed));
+                        // Exactly one of the two can be the radio key. While the fallback is
+                        // active the dedicated shortcut is unbound, so also honoring it would
+                        // let a momentarily stale fallback count one press twice against the
+                        // shared `radio_pressed` flag, swallow the matching release and leave
+                        // the transmitter keyed.
+                        let is_radio_key = if radio_follows_call.load(Ordering::Relaxed) {
+                            is_call_key
+                        } else {
+                            radio_trigger.as_ref() == Some(&event.trigger)
+                        };
 
                         if !is_call_key && !is_radio_key { continue; }
 

--- a/vacs-client/src/keybinds/runtime.rs
+++ b/vacs-client/src/keybinds/runtime.rs
@@ -100,9 +100,22 @@ pub trait KeybindListener: Send + Sync + Debug + 'static {
     fn get_external_binding(&self, _keybind: Keybind) -> Option<String> {
         None
     }
+
+    /// Whether an OS level binding exists for a keybind.
+    ///
+    /// Separate from [`Self::get_external_binding`] because the keybind engine
+    /// asks this on every key press and has no use for the binding string, which
+    /// that method has to clone out of the listener's map.
+    fn has_external_binding(&self, keybind: Keybind) -> bool {
+        self.get_external_binding(keybind).is_some()
+    }
 }
 
 pub type DynKeybindListener = Arc<dyn KeybindListener>;
+
+/// Non-owning handle to a [`DynKeybindListener`], for holders that must not keep
+/// a replaced listener (and its OS level session) alive.
+pub type WeakKeybindListener = std::sync::Weak<dyn KeybindListener>;
 
 /// Trait for platform-specific keybind emitters that inject keyboard events.
 ///

--- a/vacs-client/src/keybinds/runtime.rs
+++ b/vacs-client/src/keybinds/runtime.rs
@@ -134,7 +134,6 @@ cfg_select! {
         mod stub;
         pub use linux::LinuxKeybindEmitter as PlatformEmitter;
         pub use linux::LinuxKeybindListener as PlatformListener;
-        pub use linux::{is_portal_shortcut_bound, PortalShortcutId};
     }
     _ => {
         mod stub;

--- a/vacs-client/src/keybinds/runtime/linux.rs
+++ b/vacs-client/src/keybinds/runtime/linux.rs
@@ -79,6 +79,14 @@ impl KeybindListener for LinuxKeybindListener {
             Self::Stub(_) => None,
         }
     }
+
+    fn has_external_binding(&self, keybind: Keybind) -> bool {
+        match self {
+            Self::Wayland(l) => l.has_external_binding(keybind),
+            Self::X11(_) => false,
+            Self::Stub(_) => false,
+        }
+    }
 }
 
 pub enum LinuxKeybindEmitter {

--- a/vacs-client/src/keybinds/runtime/linux.rs
+++ b/vacs-client/src/keybinds/runtime/linux.rs
@@ -26,7 +26,6 @@
 
 mod wayland;
 mod x11;
-pub use wayland::{PortalShortcutId, is_portal_shortcut_bound};
 
 use crate::keybinds::runtime::{KeybindEmitter, KeybindListener, stub};
 use crate::keybinds::{KeyEvent, Keybind, KeybindsError};

--- a/vacs-client/src/keybinds/runtime/linux/wayland.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland.rs
@@ -177,7 +177,7 @@ pub async fn is_portal_shortcut_bound(shortcut_id: PortalShortcutId) -> bool {
     let shortcuts = Arc::new(RwLock::new(HashMap::new()));
 
     let bound = match check_existing_shortcuts(&proxy, &session, &mut None, &shortcuts).await {
-        Ok(_) => shortcuts.read().contains_key(&shortcut_id),
+        Ok(()) => shortcuts.read().contains_key(&shortcut_id),
         Err(err) => {
             log::error!("Failed to check existing Wayland Global Shortcuts: {err}");
             false

--- a/vacs-client/src/keybinds/runtime/linux/wayland.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland.rs
@@ -36,13 +36,10 @@
 mod listener;
 
 pub use listener::*;
-use std::collections::HashMap;
 
 use crate::keybinds::{Keybind, PortalAction};
 use ashpd::desktop::global_shortcuts::NewShortcut;
-use parking_lot::RwLock;
 use std::str::FromStr;
-use std::sync::Arc;
 
 /// Identifiers for shortcuts registered with the XDG Global Shortcuts portal.
 ///
@@ -163,37 +160,4 @@ impl From<Keybind> for PortalShortcutId {
             Keybind::ToggleRadioPrio => PortalShortcutId::ToggleRadioPrio,
         }
     }
-}
-
-pub async fn is_portal_shortcut_bound(shortcut_id: PortalShortcutId) -> bool {
-    let (proxy, session) = match initialize_portal(&mut None).await {
-        Ok(res) => res,
-        Err(err) => {
-            log::error!("Failed to initialize Wayland Global Shortcuts portal: {err}");
-            return false;
-        }
-    };
-
-    let shortcuts = Arc::new(RwLock::new(HashMap::new()));
-
-    let bound = match check_existing_shortcuts(&proxy, &session, &mut None, &shortcuts).await {
-        Ok(()) => shortcuts.read().contains_key(&shortcut_id),
-        Err(err) => {
-            log::error!("Failed to check existing Wayland Global Shortcuts: {err}");
-            false
-        }
-    };
-
-    // This session only exists for the duration of the query. It must be closed
-    // explicitly: the portal keeps leaked sessions alive and re-emits every
-    // shortcut signal once per session, so each leak would deliver an extra
-    // duplicate of all future Activated/Deactivated/ShortcutsChanged signals to
-    // the real listener.
-    match tokio::time::timeout(std::time::Duration::from_secs(2), session.close()).await {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => log::warn!("Failed to close global shortcuts query session: {err}"),
-        Err(_) => log::warn!("Timed out closing global shortcuts query session"),
-    }
-
-    bound
 }

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -351,24 +351,38 @@ async fn bind_shortcuts(
     // that a failure after this point can only be logged. When every shortcut is
     // already known no dialog is possible and the request completes immediately,
     // so startup waits for the response and a bind failure fails `start()`
-    // instead of leaving a listener that looks alive but delivers nothing.
-    if !all_known {
+    // instead of leaving a listener that looks alive but delivers nothing. That
+    // wait is bounded: keybind startup failure is fatal to app setup, so a
+    // merely slow portal must degrade to the early signal, not block the launch.
+    let request = if all_known {
+        let bind = proxy.bind_shortcuts(session, &shortcuts, None, Default::default());
+        tokio::pin!(bind);
+        match tokio::time::timeout(Duration::from_secs(3), &mut bind).await {
+            Ok(res) => res,
+            Err(_) => {
+                log::warn!(
+                    "BindShortcuts still pending after 3s, signaling startup completion and continuing to wait"
+                );
+                let _ = startup_tx.take().map(|tx| tx.send(Ok(())));
+                bind.await
+            }
+        }
+    } else {
         log::trace!("Signaling startup completion before binding, a dialog may block the request");
         let _ = startup_tx.take().map(|tx| tx.send(Ok(())));
+        proxy
+            .bind_shortcuts(session, &shortcuts, None, Default::default())
+            .await
     }
-
-    let request = proxy
-        .bind_shortcuts(session, &shortcuts, None, Default::default())
-        .await
-        .map_err(|err| {
-            log::error!("Failed to bind shortcuts: {err}");
-            let _ = startup_tx.take().map(|tx| {
-                tx.send(Err(KeybindsError::Listener(
-                    "Failed to bind shortcuts".to_string(),
-                )))
-            });
-            err
-        })?;
+    .map_err(|err| {
+        log::error!("Failed to bind shortcuts: {err}");
+        let _ = startup_tx.take().map(|tx| {
+            tx.send(Err(KeybindsError::Listener(
+                "Failed to bind shortcuts".to_string(),
+            )))
+        });
+        err
+    })?;
 
     let response = request.response().map_err(|err| {
         log::error!("Failed to get bind shortcuts response: {err}");
@@ -495,8 +509,13 @@ async fn run_shortcuts_listener(
 
 fn update_shortcuts_map(shortcut_map: &ShortcutMap, bound_shortcuts: &[Shortcut]) {
     let mut map = shortcut_map.write();
-    map.clear();
 
+    // Merge, do not replace: this runs once with the ListShortcuts seed and once
+    // with the BindShortcuts response, and backends disagree on which of the two
+    // carries the trigger descriptions. Whichever call reported real data wins;
+    // an empty trigger means "this backend does not report here", not "unbound"
+    // (an unbound shortcut is simply never inserted). User-driven removals
+    // arrive through the ShortcutsChanged handler, which tracks them per entry.
     for shortcut in bound_shortcuts {
         if let Ok(id) = PortalShortcutId::try_from(shortcut.id()) {
             let trigger = shortcut.trigger_description();

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -170,18 +170,17 @@ async fn setup_shortcuts_listener(
         Err(err) => return Err(err),
     };
 
-    let needs_bind =
-        match check_existing_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await {
-            Ok(needs_bind) => needs_bind,
-            Err(err) => return Err(err),
-        };
+    // Seed the map so `get_external_binding` has data while the bind request is
+    // still in flight (it can block on a user-facing dialog on first run).
+    check_existing_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
 
-    if needs_bind {
-        bind_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
-    } else {
-        log::trace!("Shortcuts already bound, signaling startup completion");
-        let _ = startup_tx.take().map(|tx| tx.send(Ok(())));
-    }
+    // BindShortcuts must run on every session, even when the portal already
+    // reports all shortcuts as configured. It is the only call that registers
+    // the shortcuts with the compositor's shortcut daemon: xdg-desktop-portal-kde
+    // used to register them on session creation too, but stopped doing so in
+    // 6.7.4 (commit 0d743a71), and xdg-desktop-portal-gnome never did - its
+    // ListShortcuts returns nothing until the session is bound.
+    bind_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
 
     let activated = proxy.receive_activated().await?;
     let deactivated = proxy.receive_deactivated().await?;
@@ -262,12 +261,18 @@ pub(super) async fn initialize_portal(
     Ok((proxy, session))
 }
 
+/// Populates `shortcuts_map` from the portal's current view of the session.
+///
+/// Portal backends differ in what this returns before [`bind_shortcuts`] has run
+/// on the session: xdg-desktop-portal-kde reports the persisted shortcuts,
+/// xdg-desktop-portal-gnome reports nothing. Treat an empty result as "unknown",
+/// not as "unbound".
 pub(super) async fn check_existing_shortcuts(
     proxy: &GlobalShortcuts,
     session: &ashpd::desktop::Session<GlobalShortcuts>,
     startup_tx: &mut Option<oneshot::Sender<Result<(), KeybindsError>>>,
     shortcuts_map: &ShortcutMap,
-) -> ashpd::Result<bool> {
+) -> ashpd::Result<()> {
     log::trace!("Checking for existing shortcuts");
     let request = proxy
         .list_shortcuts(session, Default::default())
@@ -283,36 +288,15 @@ pub(super) async fn check_existing_shortcuts(
         })?;
 
     match request.response() {
-        Ok(response) if !response.shortcuts().is_empty() => {
+        Ok(response) => {
             let shortcuts = response.shortcuts();
-            log::trace!("Found {} existing shortcuts", shortcuts.len());
-
-            let existing_ids = shortcuts.iter().map(|s| s.id()).collect::<Vec<_>>();
-            if PortalShortcutId::all()
-                .iter()
-                .all(|id| existing_ids.contains(&id.as_str()))
-            {
-                log::trace!("All required shortcuts found, skipping binding");
-                update_shortcuts_map(shortcuts_map, shortcuts);
-                Ok(false)
-            } else {
-                log::trace!(
-                    "Missing shortcuts found (have {}/{}), binding",
-                    shortcuts.len(),
-                    PortalShortcutId::all().len()
-                );
-                Ok(true)
-            }
+            log::trace!("Portal reports {} existing shortcuts", shortcuts.len());
+            update_shortcuts_map(shortcuts_map, shortcuts);
         }
-        Ok(_) => {
-            log::trace!("No existing shortcuts found, binding");
-            Ok(true)
-        }
-        Err(err) => {
-            log::warn!("Failed to get list shortcuts response, binding: {err}");
-            Ok(true)
-        }
+        Err(err) => log::warn!("Failed to get list shortcuts response: {err}"),
     }
+
+    Ok(())
 }
 
 async fn bind_shortcuts(

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -206,7 +206,7 @@ async fn setup_shortcuts_listener(
     res
 }
 
-pub(super) async fn initialize_portal(
+async fn initialize_portal(
     startup_tx: &mut Option<oneshot::Sender<Result<(), KeybindsError>>>,
 ) -> ashpd::Result<(GlobalShortcuts, ashpd::desktop::Session<GlobalShortcuts>)> {
     let proxy = match tokio::time::timeout(Duration::from_secs(5), GlobalShortcuts::new()).await {
@@ -267,7 +267,7 @@ pub(super) async fn initialize_portal(
 /// on the session: xdg-desktop-portal-kde reports the persisted shortcuts,
 /// xdg-desktop-portal-gnome reports nothing. Treat an empty result as "unknown",
 /// not as "unbound".
-pub(super) async fn check_existing_shortcuts(
+async fn check_existing_shortcuts(
     proxy: &GlobalShortcuts,
     session: &ashpd::desktop::Session<GlobalShortcuts>,
     startup_tx: &mut Option<oneshot::Sender<Result<(), KeybindsError>>>,

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -122,6 +122,12 @@ impl KeybindListener for WaylandKeybindListener {
     fn get_external_binding(&self, keybind: Keybind) -> Option<String> {
         self.get_shortcut_binding(PortalShortcutId::from(keybind))
     }
+
+    fn has_external_binding(&self, keybind: Keybind) -> bool {
+        self.shortcuts
+            .read()
+            .contains_key(&PortalShortcutId::from(keybind))
+    }
 }
 
 impl Drop for WaylandKeybindListener {

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -176,9 +176,15 @@ async fn setup_shortcuts_listener(
         Err(err) => return Err(err),
     };
 
-    // Every path past session creation funnels through the cleanup below. Bailing
-    // out early would leak the session for the life of the process, and the portal
-    // re-emits every shortcut signal once per live session.
+    // Every error return past session creation funnels through the cleanup below.
+    // Bailing out early would leak the session for the life of the process, and the
+    // portal re-emits every shortcut signal once per live session.
+    //
+    // Aborting this task still leaks it: `ashpd::desktop::Session` has no `Drop`,
+    // only an async `close()`. Both abort paths (the `await_startup` timeout and
+    // the `Drop` cleanup timeout) are slow-portal cases, so the window is narrow,
+    // but closing on abort would need the session behind a guard that spawns the
+    // close when the future is dropped.
     let res = async {
         // Seed the map so `get_external_binding` has data while the bind request is
         // still in flight (it can block on a user-facing dialog on first run).

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -170,30 +170,36 @@ async fn setup_shortcuts_listener(
         Err(err) => return Err(err),
     };
 
-    // Seed the map so `get_external_binding` has data while the bind request is
-    // still in flight (it can block on a user-facing dialog on first run).
-    check_existing_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
+    // Every path past session creation funnels through the cleanup below. Bailing
+    // out early would leak the session for the life of the process, and the portal
+    // re-emits every shortcut signal once per live session.
+    let res = async {
+        // Seed the map so `get_external_binding` has data while the bind request is
+        // still in flight (it can block on a user-facing dialog on first run).
+        check_existing_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
 
-    // BindShortcuts must run on every session, even when the portal already
-    // reports all shortcuts as configured. It is the only call that registers
-    // the shortcuts with the compositor's shortcut daemon: xdg-desktop-portal-kde
-    // used to register them on session creation too, but stopped doing so in
-    // 6.7.4 (commit 0d743a71), and xdg-desktop-portal-gnome never did - its
-    // ListShortcuts returns nothing until the session is bound.
-    bind_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
+        // BindShortcuts must run on every session, even when the portal already
+        // reports all shortcuts as configured. It is the only call that registers
+        // the shortcuts with the compositor's shortcut daemon: xdg-desktop-portal-kde
+        // used to register them on session creation too, but stopped doing so in
+        // 6.7.4 (commit 0d743a71), and xdg-desktop-portal-gnome never did - its
+        // ListShortcuts returns nothing until the session is bound.
+        bind_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
 
-    let activated = proxy.receive_activated().await?;
-    let deactivated = proxy.receive_deactivated().await?;
-    let shortcuts_changed = proxy.receive_shortcuts_changed().await?;
+        let activated = proxy.receive_activated().await?;
+        let deactivated = proxy.receive_deactivated().await?;
+        let shortcuts_changed = proxy.receive_shortcuts_changed().await?;
 
-    let res = run_shortcuts_listener(
-        key_event_tx,
-        cancellation_token,
-        &shortcuts_map,
-        activated,
-        deactivated,
-        shortcuts_changed,
-    )
+        run_shortcuts_listener(
+            key_event_tx,
+            cancellation_token,
+            &shortcuts_map,
+            activated,
+            deactivated,
+            shortcuts_changed,
+        )
+        .await
+    }
     .await;
 
     log::trace!("Cleaning up Wayland global shortcuts session");

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -291,7 +291,11 @@ async fn check_existing_shortcuts(
         Ok(response) => {
             let shortcuts = response.shortcuts();
             log::trace!("Portal reports {} existing shortcuts", shortcuts.len());
-            update_shortcuts_map(shortcuts_map, shortcuts);
+            // An empty result means "this backend does not report before binding",
+            // not "nothing is bound", so leave the map for `bind_shortcuts` to fill.
+            if !shortcuts.is_empty() {
+                update_shortcuts_map(shortcuts_map, shortcuts);
+            }
         }
         Err(err) => log::warn!("Failed to get list shortcuts response: {err}"),
     }

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -465,11 +465,10 @@ fn update_shortcuts_map(shortcut_map: &ShortcutMap, bound_shortcuts: &[Shortcut]
         }
     }
 
-    if map.is_empty() {
-        log::warn!("No shortcuts bound");
-    } else {
-        log::debug!("Updated {} shortcuts", map.len());
-    }
+    // Not a warning: this runs once per ListShortcuts and once per BindShortcuts,
+    // and an empty map is the normal state before the user has assigned any key.
+    // `bind_shortcuts` raises the single actionable warning after binding.
+    log::debug!("Updated shortcuts map with {} entries", map.len());
 }
 
 type ShortcutMap = Arc<RwLock<HashMap<PortalShortcutId, String>>>;

--- a/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
+++ b/vacs-client/src/keybinds/runtime/linux/wayland/listener.rs
@@ -188,7 +188,8 @@ async fn setup_shortcuts_listener(
     let res = async {
         // Seed the map so `get_external_binding` has data while the bind request is
         // still in flight (it can block on a user-facing dialog on first run).
-        check_existing_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
+        let all_known =
+            check_existing_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
 
         // BindShortcuts must run on every session, even when the portal already
         // reports all shortcuts as configured. It is the only call that registers
@@ -196,7 +197,7 @@ async fn setup_shortcuts_listener(
         // used to register them on session creation too, but stopped doing so in
         // 6.7.4 (commit 0d743a71), and xdg-desktop-portal-gnome never did - its
         // ListShortcuts returns nothing until the session is bound.
-        bind_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map).await?;
+        bind_shortcuts(&proxy, &session, &mut startup_tx, &shortcuts_map, all_known).await?;
 
         let activated = proxy.receive_activated().await?;
         let deactivated = proxy.receive_deactivated().await?;
@@ -285,12 +286,15 @@ async fn initialize_portal(
 /// on the session: xdg-desktop-portal-kde reports the persisted shortcuts,
 /// xdg-desktop-portal-gnome reports nothing. Treat an empty result as "unknown",
 /// not as "unbound".
+///
+/// Returns whether every required shortcut was already reported, meaning the
+/// upcoming [`bind_shortcuts`] has nothing new to ask the user about.
 async fn check_existing_shortcuts(
     proxy: &GlobalShortcuts,
     session: &ashpd::desktop::Session<GlobalShortcuts>,
     startup_tx: &mut Option<oneshot::Sender<Result<(), KeybindsError>>>,
     shortcuts_map: &ShortcutMap,
-) -> ashpd::Result<()> {
+) -> ashpd::Result<bool> {
     log::trace!("Checking for existing shortcuts");
     let request = proxy
         .list_shortcuts(session, Default::default())
@@ -314,11 +318,17 @@ async fn check_existing_shortcuts(
             if !shortcuts.is_empty() {
                 update_shortcuts_map(shortcuts_map, shortcuts);
             }
-        }
-        Err(err) => log::warn!("Failed to get list shortcuts response: {err}"),
-    }
 
-    Ok(())
+            let reported_ids = shortcuts.iter().map(|s| s.id()).collect::<Vec<_>>();
+            Ok(PortalShortcutId::all()
+                .iter()
+                .all(|id| reported_ids.contains(&id.as_str())))
+        }
+        Err(err) => {
+            log::warn!("Failed to get list shortcuts response: {err}");
+            Ok(false)
+        }
+    }
 }
 
 async fn bind_shortcuts(
@@ -326,17 +336,26 @@ async fn bind_shortcuts(
     session: &ashpd::desktop::Session<GlobalShortcuts>,
     startup_tx: &mut Option<oneshot::Sender<Result<(), KeybindsError>>>,
     shortcuts_map: &ShortcutMap,
+    all_known: bool,
 ) -> ashpd::Result<()> {
     let shortcuts = PortalShortcutId::all()
         .iter()
         .map(NewShortcut::from)
         .collect::<Vec<_>>();
 
-    log::trace!(
-        "Binding {} shortcuts, signaling startup completion to avoid timeout during setup",
-        shortcuts.len()
-    );
-    let _ = startup_tx.take().map(|tx| tx.send(Ok(())));
+    log::trace!("Binding {} shortcuts", shortcuts.len());
+
+    // When the portal may show a configuration dialog (some shortcuts are new to
+    // it), the request blocks until the user closes it, so startup must be
+    // signaled now or the engine's startup timeout fires mid-dialog. The cost is
+    // that a failure after this point can only be logged. When every shortcut is
+    // already known no dialog is possible and the request completes immediately,
+    // so startup waits for the response and a bind failure fails `start()`
+    // instead of leaving a listener that looks alive but delivers nothing.
+    if !all_known {
+        log::trace!("Signaling startup completion before binding, a dialog may block the request");
+        let _ = startup_tx.take().map(|tx| tx.send(Ok(())));
+    }
 
     let request = proxy
         .bind_shortcuts(session, &shortcuts, None, Default::default())

--- a/vacs-client/src/lib.rs
+++ b/vacs-client/src/lib.rs
@@ -92,7 +92,7 @@ pub fn run() {
 
                 let capabilities = Capabilities::default();
 
-                let state = AppStateInner::new(app.handle()).await?;
+                let state = AppStateInner::new(app.handle())?;
 
                 let transmit_config = state.config.client.transmit_config.clone();
                 let call_control_config = state.config.client.keybinds.clone();

--- a/vacs-client/src/radio.rs
+++ b/vacs-client/src/radio.rs
@@ -245,7 +245,7 @@ impl RadioConfig {
     pub async fn validate(&self, transmit_config: &TransmitConfig) -> Result<(), Error> {
         if self.integration == Some(RadioIntegration::AudioForVatsim)
             && let Some(afv_code) = self.audio_for_vatsim.as_ref().and_then(|c| c.emit)
-            && transmit_config.active_radio_trigger(true).await
+            && transmit_config.active_radio_trigger(true)
                 == Some(Trigger::Input(InputCode::Key(afv_code)))
         {
             return Err(KeybindsError::Other(

--- a/vacs-client/src/radio.rs
+++ b/vacs-client/src/radio.rs
@@ -242,7 +242,7 @@ impl RadioConfig {
         }
     }
 
-    pub async fn validate(&self, transmit_config: &TransmitConfig) -> Result<(), Error> {
+    pub fn validate(&self, transmit_config: &TransmitConfig) -> Result<(), Error> {
         if self.integration == Some(RadioIntegration::AudioForVatsim)
             && let Some(afv_code) = self.audio_for_vatsim.as_ref().and_then(|c| c.emit)
             && transmit_config.active_radio_trigger(true)

--- a/vacs-client/src/radio/commands.rs
+++ b/vacs-client/src/radio/commands.rs
@@ -45,9 +45,7 @@ pub async fn radio_set_config(
     let radio_config: RadioConfig = {
         let state = app_state.lock().await;
         let radio_config: RadioConfig = radio_config.try_into()?;
-        radio_config
-            .validate(&state.config.client.transmit_config)
-            .await?;
+        radio_config.validate(&state.config.client.transmit_config)?;
         radio_config
     };
 

--- a/vacs-client/src/remote/server.rs
+++ b/vacs-client/src/remote/server.rs
@@ -645,7 +645,8 @@ async fn dispatch_command(
         }
         KeybindsIsPortalShortcutBound => {
             let keybind = args!(args, "keybind");
-            dispatch(keybinds_is_portal_shortcut_bound(keybind).await)
+            let keybind_engine = app.state::<KeybindEngineHandle>();
+            dispatch(keybinds_is_portal_shortcut_bound(keybind_engine, keybind).await)
         }
 
         PlaybackGetEnabled => {


### PR DESCRIPTION
Plasma 6.7.4 stopped registering portal shortcuts on session creation (kde/xdg-desktop-portal-kde@0d743a71), so vacs keybinds went dead for users who had already configured them: we skipped BindShortcuts whenever ListShortcuts reported all shortcuts, and that call is the only thing that registers them with the compositor.

- Always call BindShortcuts per session; no re-prompt, since backends only show a dialog for shortcuts they don't know yet
- Resolve "does radio TX follow the call PTT key" live from the listener's shortcut map instead of caching it at engine startup; assigning or clearing the Radio PTT system shortcut now applies without a restart, and works at all on GNOME (its portal reports nothing before binding, so the old throwaway-session query always said "unbound")
- Never re-resolve the fallback while a key is held, and classify a trigger as exactly one radio key, preventing a stale flip from leaving the transmitter keyed or the call mic open
- Close the portal session on setup failure and drop the throwaway query sessions; leaked sessions duplicate every shortcut signal
- Bound the warm-start bind wait (3s, then degrade to early startup signal) so a slow portal can't fail app launch, while a denied bind still fails start() instead of leaving a dead listener
- Unit tests for the fallback resolution and trigger classification