### PR TITLE
fix(vacs-client): stop radio TX when the keybind engine is reconfigured

### DIFF
--- a/vacs-client/src/keybinds/engine.rs
+++ b/vacs-client/src/keybinds/engine.rs
@@ -366,7 +366,19 @@ impl KeybindEngine {
     fn reset_input_state(&self) {
         self.call_pressed.store(false, Ordering::Relaxed);
         self.radio_pressed.store(false, Ordering::Relaxed);
-        self.radio_transmitting.store(false, Ordering::Relaxed);
+
+        // The rx task is aborted before this runs, so the key release that would
+        // have keyed the radio down will never be processed. Without sending it
+        // here, reconfiguring while the radio key is held leaves the radio
+        // transmitting with no key left to release it.
+        if self.radio_transmitting.swap(false, Ordering::Relaxed) {
+            log::debug!("Radio transmit: false (input state reset)");
+
+            let radio_handle = self.app.state::<RadioHandle>().inner().clone();
+            tauri::async_runtime::spawn(async move {
+                Self::set_radio_transmit(&radio_handle, TransmissionState::Inactive).await;
+            });
+        }
 
         let muted = match &self.call_mic_mode {
             CallMicMode::PushToTalk => true,


### PR DESCRIPTION
Changing the transmit or keybind config while the radio key is held left TrackAudio keyed: the rx task that would have sent the release is aborted before the reset runs, and no key remains to release it. radio_set_config happened to escape this by dropping the RadioHandle outright.