### PR TITLE
fix(vacs-client): skip early tasks that race the app state setup

### DIFF
--- a/vacs-client/src/app.rs
+++ b/vacs-client/src/app.rs
@@ -32,6 +32,11 @@ pub(crate) mod window;
 pub fn handle_deep_link(app: AppHandle, url: String) {
     let url = url.to_string();
     tauri::async_runtime::spawn(async move {
+        if app.try_state::<AppState>().is_none() {
+            log::warn!("Ignoring deep link, app startup has not finished yet");
+            return;
+        }
+
         if let Err(err) = auth::handle_auth_callback(&app, &url).await {
             app.emit("auth:error", Value::Null).ok();
             app.emit::<FrontendError>("error", err.into()).ok();

--- a/vacs-client/src/audio/manager.rs
+++ b/vacs-client/src/audio/manager.rs
@@ -605,6 +605,13 @@ async fn handle_playback_stream_error(
     device_type: PlaybackDeviceType,
     app: AppHandle,
 ) {
+    if app.try_state::<AppState>().is_none() {
+        log::warn!(
+            "Dropping {device_type} stream error, app startup has not finished yet: {err:?}"
+        );
+        return;
+    }
+
     let device_changed = matches!(err, AudioError::StreamInvalidated);
     let in_restart_cooldown = restarted_at.is_some_and(|t| t.elapsed() < RESTART_COOLDOWN);
 


### PR DESCRIPTION
audio manager and deep link handling could try to access state before it was fully managed, leading to (silent) panics